### PR TITLE
rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Microwave imaging using portable "Tailgater" satellite antenna. 
+#Microwave imaging using portable "Tailgater" satellite antenna.
 
 Gabe Emerson / Saveitforparts 2023. Email: gabe@saveitforparts.com
 
@@ -6,19 +6,18 @@ Video demo: https://youtu.be/lVOTZxNCgTM
 
 **Introduction:**
 
-This code controls a portable satellite antenna over USB using serial commands. 
+This code controls a portable satellite antenna over USB using serial commands.
 The dish_scan.py program aims the dish to a selected portion of the sky and records
-the RF signal strength. The dish_image.py program reads the resulting data and 
-creates	a heatmap of the scanned area. Frequencies using stock Tailgater antenna 
+the RF signal strength. The dish_image.py program reads the resulting data and
+creates a heatmap of the scanned area. Frequencies using stock Tailgater antenna
 hardware will be in the Ku band (~11ghz)
 
-Please note that the author is not an expert in Python, Linux, satellites, or 
+Please note that the author is not an expert in Python, Linux, satellites, or
 radio theory! This code is very experimental, amateur, and not optimized. It will
 likely void any warranty your Tailgater antenna may have. There are probably better,
-faster, and more efficient ways	to do some of the functions and calculations in 
+faster, and more efficient ways to do some of the functions and calculations in
 the code. Please feel free to fix, improve, or add to anything (If you do, I'd
-love to hear what you did and how it worked!)    
-
+love to hear what you did and how it worked!)
 
 **Applications:**
 
@@ -26,66 +25,61 @@ love to hear what you did and how it worked!)
 - Surveying an environment or room for microwave radiation
 - Imaging an environment using ambient or reflected microwaves from Ku band source
 - Imaging other wavelengths with a different feedhorn or LNB (not tested)
-- Integration with an SDR and other antenna elements (not tested) 
-
+- Integration with an SDR and other antenna elements (not tested)
 
 **Hardware Requirements:**
 
 This code has been developed and tested with a Dish Network "Tailgater" portable
-satellite antenna. Specifically, a 2014 version in an octagonal-ish enclosure 
-with a USB "A" connector on the mainboard (located inside the enclosure, behind 
-the dish reflector). There are many variations, models, and versions of this 
+satellite antenna. Specifically, a 2014 version in an octagonal-ish enclosure
+with a USB "A" connector on the mainboard (located inside the enclosure, behind
+the dish reflector). There are many variations, models, and versions of this
 antenna, including Wallace, VuQube, Dish, King Controls, etc. I have not found a
-consistent model numbering scheme, so I don't know how to identify the correct 
+consistent model numbering scheme, so I don't know how to identify the correct
 model without opening the top and looking for a USB port. Other models have USB
-mini or other ports, and some appear to have jumpers for 9-pin serial. I have not 
+mini or other ports, and some appear to have jumpers for 9-pin serial. I have not
 tested this software on any of those variations.
 
 My test unit uses firmware version "pragelato.h 704 2013-08-09 03:41:27Z rudrava"
 Other versions may have different console commands available.
 
 This code has been tested sucessfully on a range of Linux PCs, from 686-class using
-a low-resource distro, to higher-end running a modern distribution. 
-
+a low-resource distro, to higher-end running a modern distribution.
 
 **Notes on power supply:**
 
-The USB connection only provides data to/from the dish. Power for the board, LNB, and 
-motors comes from the coax "F" connector. This needs between 13-18V DC, center pin 
+The USB connection only provides data to/from the dish. Power for the board, LNB, and
+motors comes from the coax "F" connector. This needs between 13-18V DC, center pin
 positive. Normally this is provided by a set-top box or satellite reciever. Power can
 also be provided by an in-line injector for powered antennas, a meter such as V8 Finder,
 or simply a DC adapter wired to a coax cable. Providing 13V will tell the LNB to use
-vertical polarity and 18V will use horizontal polarity. 
-
+vertical polarity and 18V will use horizontal polarity.
 
 **Package Requirements:**
 
 dish_scan.py uses the numpy, pyserial and regex packages. dish_image uses matplotlib.
 They can be installed individually or by running "pip install -r requirements.txt"
 
-
 **Setting up / testing Tailgater console:**
 
 To connect to a Tailgater antenna with USB A port, you will need an A-to-A cable
-(available online). 
+(available online).
 
 You can check for proper connection by running "lsusb" on Linux. The dish should show
 up as "Microchip Technology, Inc. CDC RS-232 Emulation Demo".
 
 Run "dmesg | grep tty" to see which port the dish is using. This is usually something
 like /dev/ttyACM0, although I have seen it jump to ttyACM1 or ACM2 if the power or USB
-connection are interrupted. If your Tailgater is NOT on /dev/ttyACM0 you will need to 
-edit line 15 of dish_scan.py to reflect the correct port. 
-	
+connection are interrupted. If your Tailgater is NOT on /dev/ttyACM0 you will need to
+edit line 15 of dish_scan.py to reflect the correct port.
+
 To connect to the serial console on the dish, run "screen /dev/ttyACM0" (or appropriate
 port) on Linux, or use a Windows serial terminal to connect to the usb device (typically
 com3 or similar). You will initially get a blank screen. Typing "help" should return a
-menu of available commands and a "GO>" prompt. 
-	
-Note that the console does not accept backspace, so if you make a mistake while typing,
-just hit enter to clear the console. If necessary, close the console or unplug the 
-dish to avoid a motor overrun. 
+menu of available commands and a "GO>" prompt.
 
+Note that the console does not accept backspace, so if you make a mistake while typing,
+just hit enter to clear the console. If necessary, close the console or unplug the
+dish to avoid a motor overrun.
 
 **Positioning the dish:**
 
@@ -95,81 +89,77 @@ counterclockwise from the coax jack (looking down at the dish from above). Azimu
 directly opposite the coax jack, and azimuth 270 is 90 degrees clockwise from the RF jack.
 This is technically "backwards" from a standard compass heading. The code is written to
 take this into account, but please note that image and array outputs will show azimuth in
-the dish's reference plane, opposite of standard compass or orbital azimuth. 
-		
+the dish's reference plane, opposite of standard compass or orbital azimuth.
+
 Generally I place the dish with the coax connector facing due North (for scans of the
 Southern sky), but you can place it in any orientation you want. The dish scans left to
 right, incrementing up from the starting elevation. Remember the coordinate system is
-"backwards" compared to standard compass headings.  
-
+"backwards" compared to standard compass headings.
 
 **Running a scan:**
 
 Once the dish is connected, powered, and ready on a USB port, run:
 "python3 dish_scan.py"
-You will be prompted for the starting and ending azimuth and elevation of your scan. 
+You will be prompted for the starting and ending azimuth and elevation of your scan.
 Valid azimuth range is 0-360, and valid elevations are 5-70 degrees (outside of these
-values may overrun the motors). If you enter a value outside the valid range, the 
+values may overrun the motors). If you enter a value outside the valid range, the
 program will use the minimum or maximum as appropriate. The default values are from
-azimuth 90 to 270 (West to East in the dish's coordinate system), and from elevation 5 
+azimuth 90 to 270 (West to East in the dish's coordinate system), and from elevation 5
 to 70 degrees. This covers most of the Southern sky (if the dish is placed with coax jack
-aiming due North). A scan with default values takes approximately 3.5 hours due to the 
+aiming due North). A scan with default values takes approximately 3.5 hours due to the
 minimum rfwatch runtime of 1 second. Scans of smaller azimuth/elevation ranges should take
-less time. Estimated scan time for your parameters will be shown once the scan starts. 
-	
+less time. Estimated scan time for your parameters will be shown once the scan starts.
+
 During the scan, the current azimuth, elevation, and signal strength will be displayed for
-each dish position. A preview image, "result-<timestamp>.png" will be created and will 
+each dish position. A preview image, "result-<timestamp>.png" will be created and will
 update live during the scan. On Gnome Image Viewer, this file should automatically refresh as
 it updates. It will be very small (x pixels equal to your scan's azimuth range, and y pixels
 equal to your scan's elevation range). However, it should be enough to get an idea if the
-scan is working. 
+scan is working.
 
-	
 **Generating an image from a scan:**
-	
+
 Once a scan has completed, you will have three output files with the same timestamp:
 
 - "result-<timestamp>.png"         The low-resolution preview image.
-	
+
 - "raw-data-<timestamp>.txt"       The raw scan values in a numpy array.
-	
+
 - "scan-settings-<timestamp>.txt"  The scan parameters (start and end azimuth / elevation)
-	
-dish_image.py will use the two text files to create a heatmap of your scan. Run the code 
+
+dish_image.py will use the two text files to create a heatmap of your scan. Run the code
 along with the name of the raw-data scan you want to process. For example:
 "python3 dish_image.py raw-data-20230322-153935.txt"
-	
+
 The code will load the corresponding scan-settings file automatically, and opens a
-heatmap of the scan in a new window. You can save this heatmap for later use. 
+heatmap of the scan in a new window. You can save this heatmap for later use.
 
 I noticed an issue where counterclockwise rows were offset slightly from clockwise rows,
-this seems to be a combination of indexing and inconsistencies with motor movements. 
+this seems to be a combination of indexing and inconsistencies with motor movements.
 The fix_image.py script is an alternate version of dish_image that outputs a better
 bitmap from scans run with my dish. It does this by shifting every other row in the
 signal strength array 3 places to the right. Each Tailgater unit might be a little
 different, and the range of elevation values can alter this offset. You may have to play
 with the last number on line 38 to get the best image.
 
-	
 **Example Images:**
 I have included several example images to show what a scan looks like:
-	 
-- "dish_image example.png"  The result of running a default scan with dish_scan.py and 
-processing with dish_image.py. Shows geostationary TV satellites.
-				  
-- "satellite overlay.png"   The previous file overlaid on a panoramic photo of the same area. 
-Note that trees, roof overhangs, and power poles are visible in RF.
-				  
+
+- "dish_image example.png"  The result of running a default scan with dish_scan.py and
+  processing with dish_image.py. Shows geostationary TV satellites.
+
+- "satellite overlay.png"   The previous file overlaid on a panoramic photo of the same area.
+  Note that trees, roof overhangs, and power poles are visible in RF.
+
 - "satellite preview.png"   A scaled-up version of the "result" preview generated during a scan.
-	
+
 - "room overlay.png"        An overlay of a default scan run indoors, showing microwave RF
-coming from a poorly-shielded PC tower (lower right). 
-				  
-- "house.png"		  A structure scan comparing KU band (with "hsv" colormap), visible
-light, and 50% overlay of each. 
-				  
-- "tailgater.png"		  Example of the antenna unit used for this project.
-		
+  coming from a poorly-shielded PC tower (lower right).
+
+- "house.png"          A structure scan comparing KU band (with "hsv" colormap), visible
+  light, and 50% overlay of each.
+
+- "tailgater.png"          Example of the antenna unit used for this project.
 
 **Example Files**
 
@@ -181,22 +171,20 @@ I have included some example data files output by dish_scan.py, for processing w
 
 - "result-20230321-193653.png":     Preview image created by dish_scan (not used by dish_image)
 
-
 **Additional notes:**
-	
+
 The dish_scan.py code contains code for two resolution settings, however the high setting does
 NOT currently work with my dish due to motor drift. Low resolution (default) uses azangle and
 elangle commands on the Tailgater console, so each scan position is one degree. The high-
-resolution version would have used the "nudge" commands available in the Tailgater console. 
-However, these do not seem to be consistent in each direction, so the dish drifts off center 
-over the course of a scan and causes a distorted image. Currently the "resolution" setting is 
+resolution version would have used the "nudge" commands available in the Tailgater console.
+However, these do not seem to be consistent in each direction, so the dish drifts off center
+over the course of a scan and causes a distorted image. Currently the "resolution" setting is
 disabled, you can re-enable it by un-commenting lines 61-64 and commenting out line 66. Do so
-at your own risk of frustration and possibly hitting motor limits. 
+at your own risk of frustration and possibly hitting motor limits.
 
 The heatmap generated by dish_image.py uses CMRmap. If you wish to use another colormap, you can
 change line 67 of dish_image.py. I also like "seismic" and "gnuplot2", but I feel that they lose
-some definition on the background landscape. "hsv" may also be useful for noisy scans. 
-	
+some definition on the background landscape. "hsv" may also be useful for noisy scans.
+
 If you use this code and encounter any problems, feel free to email me at the address at the top
 of this file. However, I may have to refer back to this myself to remember how it works! 
-

--- a/dish_scan.py
+++ b/dish_scan.py
@@ -1,419 +1,160 @@
-#Python program to scan with Dish Tailgater and output signal strength bitmap
-#Gabe Emerson / Saveitforparts 2023, Email: gabe@saveitforparts.com
+# Python program to scan with Dish Tailgater and output signal strength bitmap
+# Gabe Emerson / Saveitforparts 2023, Email: gabe@saveitforparts.com
 
-import serial
-import time
-from PIL import Image
-import regex as re
 import numpy as np
+from PIL import Image
 
-#generate timestamp
-timestr = time.strftime("%Y%m%d-%H%M%S")
+from lib.console_messages import error, info
+from lib.dish_commands import DishCommands
+from lib.questions import get_valid_int
+from lib.time_formatting import timestamp
 
-#define "dish" as the serial port device to interface with
-dish = serial.Serial(
-	port='/dev/ttyACM0',
-	baudrate = 9600,
-	parity=serial.PARITY_NONE,
-	stopbits=serial.STOPBITS_ONE,
-	bytesize=serial.EIGHTBITS,
-	timeout=1)
+startup_timestamp = timestamp()
 
-print ("Serial port connected")
-print ('')
+PRINT_DEBUG = True
+PRINT_INFO = True
 
-#Prompt for scan parameters, with default values and valid range checks
-az_start = int(input('Starting Azimuth in degrees (0-360, default 90): ') or 90)
+dish_cmd = DishCommands()
 
-if az_start < 0:
-	print('Azimuth out of range, setting to 0')
-	az_start=0
-if az_start > 360:
-	print('Azimuth out of range, setting to 360')
-	az_start=360
 
-az_end = int(input('Ending Azimuth in degrees (default 270): ') or 270)
-if az_end < 0:
-	print('Azimuth out of range, setting to 0')
-	az_end=0
-if az_end > 360:
-	print('Azimuth out of range, setting to 360')
-	az_end=360
+def writeout_results():
+	global sky_data
+	global signal_strength
+	global startup_timestamp
+	
+	# record raw data to array
+	sky_data[abs(elevation - el_end), abs(azimuth - az_end)] = signal_strength
+	# write to text file
+	np.savetxt(f"raw-data-" + startup_timestamp + ".txt", sky_data)
+	
+	# create preview bitmap
+	image_x = abs(azimuth - az_end)  # write bitmap the same way the dish is scanning
+	image_y = abs(elevation - el_end)  # write bitmap the same way the dish is scanning
+	data[image_x, image_y] = (signal_strength % 255, 0, 0)
+	# write bitmap to time stamped image file
+	sky_image.save('result-' + startup_timestamp + '.png')
 
-el_start = int(input('Starting Elevation in degrees (5-70, default 5): ') or 5)
-if el_start < 5:
-	print('Elevation out of range, setting to 5')
-	el_start=5
-if el_start > 70:
-	print('Elevation out of range, setting to 70')
-	el_start=70
 
-el_end = int(input('Ending Elevation in degrees (default 70): ') or 70)
-if el_end < 5:
-	print('Elevation out of range, setting to 5')
-	el_end=5
-if el_end > 70:
-	print('Elevation out of range, setting to 70')
-	el_end=70
+# Prompt for scan parameters, with default values and valid range checks
+
+az_start = get_valid_int("minimum Azimuth (in degrees)", 90, minimum=0, maximum=360)
+az_end = get_valid_int("maximum Azimuth (in degrees)", 270, minimum=0, maximum=360)
+el_start = get_valid_int("minimum Elevation (in degrees)", 5, minimum=5, maximum=70)
+el_end = get_valid_int("maximum Elevation (in degrees)", 70, minimum=5, maximum=70)
+
+if az_start > az_end:
+	error("the minimal Azimuth must be smaller than the maximum")
+if el_start > el_end:
+	error("the minimal elevation must be smaller than the maximum")
 
 #########This method doesn't work reliably, "nudge" results in too much motor drift on azimuth axis
-#Choose between between azangle/elangle for low res and aznudge/elnudge for high res
-#resolution = int(input('Resolution (1=low, 2=high, default 1): ') or 1)
-#if not resolution in (1,2):
+# Choose between between azangle/elangle for low res and aznudge/elnudge for high res
+# resolution = int(input('Resolution (1=low, 2=high, default 1): ') or 1)
+# if not resolution in (1,2):
 #	print('Unknown selection, setting to 1 (low)')
 #	resolution=1 
 
-resolution = 1 #hard-coding this until if/when we figure out reliable motor steps smaller than full degrees
+resolution = 1  # hard-coding this until if/when we figure out reliable motor steps smaller than full degrees
 
+np.savetxt("scan-settings-" + startup_timestamp + ".txt", (az_start, az_end, el_start, el_end, resolution))
 
-np.savetxt("scan-settings-" + timestr +".txt", (az_start,az_end,el_start,el_end,resolution))	
-
-if resolution==1: #standard scan using angles
+if resolution == 1:  # standard scan using angles
 	az_range = az_end - az_start
 	el_range = el_end - el_start
-
-	#Provide runtime estimate (I'm making a rough guess based on prior runs on two different computers)
+	
+	# Provide runtime estimate (I'm making a rough guess based on prior runs on two different computers)
 	time_est = az_range * el_range
-	print ('Estimated scan time with your parameters is ', (time_est+(time_est/6))/60, ' minutes.')
-	print ('')
-
-	#create bitmap to preview signal strengths
-	sky_image = Image.new('RGB', [az_range+1,el_range+1], 255) 
+	info('Estimated scan time with your parameters is ', (time_est + (time_est / 6)) / 60, ' minutes.\n')
+	
+	# create bitmap to preview signal strengths
+	sky_image = Image.new('RGB', [az_range + 1, el_range + 1], 255)
 	data = sky_image.load()
-
-	#create 2D array for raw signal strengths
-	sky_data = np.zeros((el_range+1,az_range+1))
-
-	print ("Moving dish to staring position...")
-	#initialize starting dish position
-	#for some reason, the dish only receives single char from each write(), so send one at a time
-	#(wow much kludge, such ugly)
-	dish.write(b'a')
-	dish.write(b'z')
-	dish.write(b'a')
-	dish.write(b'n')
-	dish.write(b'g')
-	dish.write(b'l')
-	dish.write(b'e')
-	dish.write(b' ')
-	angle=str(az_start)
-	if (len(angle)==3):
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-		dish.write(angle[2].encode())
-	elif len(angle)==2:
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-	else: 
-	        #single-digit number
-	        dish.write(angle.encode())
-	dish.write(b'\r')
-
-	time.sleep(5)   #Give motors time to drive dish to scan origin
-	dish.flush()
-	dish.reset_output_buffer()
-
-	dish.write(b'e')
-	dish.write(b'l')
-	dish.write(b'a')
-	dish.write(b'n')
-	dish.write(b'g')
-	dish.write(b'l')
-	dish.write(b'e')
-	dish.write(b' ')
-	angle=str(el_start)
-	if (len(angle)==3):
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-		dish.write(angle[2].encode())
-	elif len(angle)==2:
-	        dish.write(angle[0].encode())
-	        dish.write(angle[1].encode())
-	else: 
-	        #single-digit number
-	        dish.write(angle.encode())
-	dish.write(b'\r')
-	dish.flush()
-	dish.reset_output_buffer()
-	dish.reset_input_buffer()
-	time.sleep(5)
-		
-	direction=0		
-	#aiming loop
-	#valid elangle range appears to be ~2-73 degrees, use slightly smaller range to avoid motor overrun. 
-	for elevation in range (el_start,el_end):
-		direction=direction+1
-		#valid azangle 0-360. Remember dish increments ccw. 
-		for azimuth in range (az_start,az_end):
 	
-			if (direction % 2) == 0: 		  #check for sweep direction
-				azimuth = abs(azimuth-az_end)+az_start  	  #increment backwards on even numbered loops
-				
-			print("Azimuth: ", azimuth, ", Elevation: ", elevation)  #display current position
-
-			#command dish to next azimuth	
-			dish.write(b'a')
-			dish.write(b'z')
-			dish.write(b'a')
-			dish.write(b'n')
-			dish.write(b'g')
-			dish.write(b'l')
-			dish.write(b'e')
-			dish.write(b' ')
-			#we have to break up 3 and 2 digit numbers into single characters
-			angle=str(azimuth)
-			if (len(angle)==3):
-			        dish.write(angle[0].encode())
-			        dish.write(angle[1].encode())
-			        dish.write(angle[2].encode())
-			elif len(angle)==2:
-			        dish.write(angle[0].encode())
-			        dish.write(angle[1].encode())
-			else: #shouldn't need this for typical range, but might want it later
-			        #single-digit number
-			        dish.write(angle.encode())
-			dish.write(b'\r')
+	# create 2D array for raw signal strengths
+	sky_data = np.zeros((el_range + 1, az_range + 1))
+	
+	# move dish to start position
+	dish_cmd.init_dish_position(az_start, el_start)
+	
+	direction = 0
+	# aiming loop
+	# valid elangle range appears to be ~2-73 degrees, use slightly smaller range to avoid motor overrun.
+	for elevation in range(el_start, el_end):
+		direction = direction + 1
+		# valid azangle 0-360. Remember dish increments ccw.
+		for azimuth in range(az_start, az_end):
 			
-			#this seems necessary to avoid SerialException issue? (probably also kludgy)
-			while True:
-				try:
-					dish.reset_input_buffer() #avoid overflow 
-				
-					#request signal strength 
-					dish.write(b'r')
-					dish.write(b'f')
-					dish.write(b'w')
-					dish.write(b'a')
-					dish.write(b't')
-					dish.write(b'c')
-					dish.write(b'h')
-					dish.write(b' ')
-					dish.write(b'1')
-					dish.write(b'\r')
-		
-					dish.flush()
-					dish.reset_output_buffer()
-	                		                					                    
-					reply = dish.read(207).decode().strip()      #read dish response
-					header, *readings = reply.split('[5D')       #Split into list of signal strengths
-					output = readings[0]			     #grab first list element
-					output = re.sub(r'\p{C}', '', output)        #remove any control chars
-					output = re.sub('[^\d]', '', output).strip() #clean up partial garbage
-	
-					signal_strength = int(output)                #convert to integer
-	
-				except serial.SerialException as e:
-					#dish hasn't replied yet
-					time.sleep(0.1)
-					continue
-				else:
-					print('')
-				break
-	
-			print('Signal: ', signal_strength)    #display signal strength
-	
-			#record raw data to array
-			sky_data[abs(elevation-el_end),abs(azimuth-az_end)]=signal_strength
-			#write to text file
-			np.savetxt(f"raw-data-" + timestr +".txt", sky_data)
+			if (direction % 2) == 0:  # check for sweep direction
+				azimuth = abs(azimuth - az_end) + az_start  # increment backwards on even numbered loops
 			
-			#create preview bitmap	
-			image_x = abs(azimuth-az_end)    #write bitmap the same way the dish is scanning
-			image_y = abs(elevation-el_end)   #write bitmap the same way the dish is scanning
-			data[image_x,image_y] = (signal_strength % 255,	0, 0)
-			#write bitmap to time stamped image file
-			sky_image.save('result-' + timestr +'.png')
-
-
-		#command dish to next elevation
-		dish.write(b'e')
-		dish.write(b'l')
-		dish.write(b'a')
-		dish.write(b'n')
-		dish.write(b'g')
-		dish.write(b'l')
-		dish.write(b'e')
-		dish.write(b' ')
-		#We have to break up 2 digit numbers into single characters
-		angle=str(elevation)
-		if len(angle)==2: #will only ever have 1 and 2-digit elevations
-		        dish.write(angle[0].encode())
-		        dish.write(angle[1].encode())
-		else: 
-		        #single-digit number
-		        dish.write(angle.encode())
-		dish.write(b'\r')
+			info("Azimuth: ", azimuth, ", Elevation: ", elevation)  # display current position
+			
+			# command dish to next azimuth
+			dish_cmd.goto_azimuth(azimuth)
+			
+			signal_strength = dish_cmd.get_signal_strength()
+			
+			info('Signal: %i' % signal_strength)  # display signal strength
+			
+			writeout_results()
+		
+		# command dish to next elevation
+		dish_cmd.goto_elevation(elevation)
 
 #####################################Currently resolution 2 is not enabled, because "nudge" isn't consistent
-elif resolution==2: #high res scan using nudge instead of angle
-
-	#"nudge" is "about 0.2 degrees", so for each degree in range we have 5 dish positions
-	az_range = (az_end - az_start)*5
-	el_range = (el_end - el_start)*5
-
-	#Provide runtime estimate (I'm making a rough guess based on prior runs on two different computers)
+elif resolution == 2:  # high res scan using nudge instead of angle
+	
+	# "nudge" is "about 0.2 degrees", so for each degree in range we have 5 dish positions
+	az_range = (az_end - az_start) * 5
+	el_range = (el_end - el_start) * 5
+	
+	# Provide runtime estimate (I'm making a rough guess based on prior runs on two different computers)
 	time_est = az_range * el_range
-	print ('Estimated scan time with your parameters is ', (time_est+(time_est/6))/60, ' minutes.')
-	print ('')
-
-	#create bitmap to preview signal strengths
-	sky_image = Image.new('RGB', [az_range+1,el_range+1], 255) 
+	print('Estimated scan time with your parameters is ', (time_est + (time_est / 6)) / 60, ' minutes.')
+	print('')
+	
+	# create bitmap to preview signal strengths
+	sky_image = Image.new('RGB', [az_range + 1, el_range + 1], 255)
 	data = sky_image.load()
-
-	#create 2D array for raw signal strengths
-	sky_data = np.zeros((el_range+1,az_range+1))
-
-	print ("Moving dish to staring position...")
-	#initialize starting dish position
-	#for some reason, the dish only receives single char from each write(), so send one at a time
-	#(wow much kludge, such ugly)
-	dish.write(b'a')
-	dish.write(b'z')
-	dish.write(b'a')
-	dish.write(b'n')
-	dish.write(b'g')
-	dish.write(b'l')
-	dish.write(b'e')
-	dish.write(b' ')
-	angle=str(az_start)
-	if (len(angle)==3):
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-		dish.write(angle[2].encode())
-	elif len(angle)==2:
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-	else: 
-	        #single-digit number
-	        dish.write(angle.encode())
-	dish.write(b'\r')
-
-	time.sleep(5)   #Give motors time to drive dish to scan origin
-	dish.flush()
-	dish.reset_output_buffer()
-
-	dish.write(b'e')
-	dish.write(b'l')
-	dish.write(b'a')
-	dish.write(b'n')
-	dish.write(b'g')
-	dish.write(b'l')
-	dish.write(b'e')
-	dish.write(b' ')
-	angle=str(el_start)
-	if (len(angle)==3):
-		dish.write(angle[0].encode())
-		dish.write(angle[1].encode())
-		dish.write(angle[2].encode())
-	elif len(angle)==2:
-	        dish.write(angle[0].encode())
-	        dish.write(angle[1].encode())
-	else: 
-	        #single-digit number
-	        dish.write(angle.encode())
-	dish.write(b'\r')
-	dish.flush()
-	dish.reset_output_buffer()
-	dish.reset_input_buffer()
-	time.sleep(5)
-	direction=0		
-					
-	#aiming loop
-	#valid elangle range appears to be ~2-73 degrees, use slightly smaller range to avoid motor overrun. 
-	for elevation in range (0,el_range):
-		direction = direction+1
-		#valid azangle 0-360. Remember dish increments ccw. 
-		for azimuth in range (0,az_range):
 	
-			if (direction % 2) == 0: 		  #check for sweep direction
-				azimuth = (abs(azimuth-az_range))  	  #increment backwards on even numbered loops
-				
-			print("X: ", azimuth, ", Y: ", elevation)  #display current position
-
-			#command dish to next azimuth	
-			dish.write(b'a')
-			dish.write(b'z')
-			dish.write(b'n')
-			dish.write(b'u')
-			dish.write(b'd')
-			dish.write(b'g')
-			dish.write(b'e')
-			dish.write(b' ')
-			dish.write(b'c')
-			if not (direction % 2) == 0: 		  #check for sweep direction
-				dish.write(b'c')			
-			dish.write(b'w')
-			dish.write(b'\r')
+	# create 2D array for raw signal strengths
+	sky_data = np.zeros((el_range + 1, az_range + 1))
+	
+	dish_cmd.init_dish_position(az_start, el_start)
+	
+	direction = 0
+	
+	# aiming loop
+	# valid elangle range appears to be ~2-73 degrees, use slightly smaller range to avoid motor overrun.
+	for elevation in range(0, el_range):
+		direction = direction + 1
+		# valid azangle 0-360. Remember dish increments ccw.
+		for azimuth in range(0, az_range):
 			
-			#this seems necessary to avoid SerialException issue? (probably also kludgy)
-			while True:
-				try:
-					dish.reset_input_buffer() #avoid overflow 
-				
-					#request signal strength 
-					dish.write(b'r')
-					dish.write(b'f')
-					dish.write(b'w')
-					dish.write(b'a')
-					dish.write(b't')
-					dish.write(b'c')
-					dish.write(b'h')
-					dish.write(b' ')
-					dish.write(b'1')
-					dish.write(b'\r')
+			if (direction % 2) == 0:  # check for sweep direction
+				azimuth = (abs(azimuth - az_range))  # increment backwards on even numbered loops
+			
+			print("X: ", azimuth, ", Y: ", elevation)  # display current position
+			
+			if not (direction % 2) == 0:
+				dish_cmd.nudge_right()
+			else:
+				dish_cmd.nudge_left()
+			
+			signal_strength = dish_cmd.get_signal_strength()
+			
+			print('Signal: ', signal_strength)  # display signal strength
+			
+			writeout_results()
 		
-					dish.flush()
-					dish.reset_output_buffer()
-	                		                					                    
-					reply = dish.read(207).decode().strip()      #read dish response
-					header, *readings = reply.split('[5D')       #Split into list of signal strengths
-					output = readings[0]			     #grab first list element
-					output = re.sub(r'\p{C}', '', output)        #remove any control chars
-					output = re.sub('[^\d]', '', output).strip() #clean up partial garbage
-	
-					signal_strength = int(output)                #convert to integer
-	
-				except serial.SerialException as e:
-					#dish hasn't replied yet
-					time.sleep(0.1)
-					continue
-				else:
-					print('')
-				break
-	
-			print('Signal: ', signal_strength)    #display signal strength
-	
-			#record raw data to array
-			sky_data[abs(elevation-el_range),abs(azimuth-az_range)]=signal_strength
-			#write to text file
-			np.savetxt(f"raw-data-" + timestr +".txt", sky_data)
-			
-			#create preview bitmap	
-			image_x = abs(azimuth-az_range)    #write bitmap the same way the dish is scanning
-			image_y = abs(elevation-el_range)   #write bitmap the same way the dish is scanning
-			data[image_x,image_y] = (signal_strength % 255,	0, 0)
-			#write bitmap to time stamped image file
-			sky_image.save('result-' + timestr +'.png')
-			
-			
-		#command dish to next elevation
-		dish.write(b'e')
-		dish.write(b'l')
-		dish.write(b'n')
-		dish.write(b'u')
-		dish.write(b'd')
-		dish.write(b'g')
-		dish.write(b'e')
-		dish.write(b' ')
-		dish.write(b'u')
-		dish.write(b'p')
-		dish.write(b'\r')	
+		# command dish to next elevation
+		dish_cmd.nudge_up()
+
 ##################################Resolution 2 not working, ignore above elif
 
-else: #possibly implement medium resolution in the future?
-	print ('')
+else:  # possibly implement medium resolution in the future?
+	print('')
 
-print ('Scan complete!')
-#close serial connection
-dish.close()
-
+info('Scan complete!')
+# close serial connection
+dish_cmd.close_conn()

--- a/lib/console_messages.py
+++ b/lib/console_messages.py
@@ -1,0 +1,19 @@
+def error(message: str):
+	print("Error: %s" % message)
+	exit(1)
+
+
+def warning(message: str):
+	print("Warning: %s" % message)
+
+
+def debug(message: str):
+	global PRINT_DEBUG
+	if PRINT_DEBUG:
+		print("Debug: %s" % message)
+
+
+def info(message: str):
+	global PRINT_INFO
+	if PRINT_INFO:
+		print("Info: %s" % message)

--- a/lib/dish_commands.py
+++ b/lib/dish_commands.py
@@ -1,0 +1,355 @@
+from time import sleep
+
+import regex as re
+from serial import SerialException
+
+from console_messages import debug, error, info, warning
+from dish_serial import DishDevice
+
+MOTION_TIME_360_AZIMUTH = 5
+MINIMAL_MOTION_TIME_AZIMUTH = 0.2
+NUDGE_MOTION_TIME_AZIMUTH = 0.2
+
+MOTION_TIME_180_ELEVATION = 5
+MINIMAL_MOTION_TIME_ELEVATION = 0.2
+NUDGE_MOTION_TIME_ELEVATION = 0.2
+
+MINIMAL_AZIMUTH_INPUT = 0
+MAXIMAL_AZIMUTH_INPUT = 359
+
+MINIMAL_ELEVATION_INPUT = -179
+MAXIMAL_ELEVATION_INPUT = 179
+
+NUDGE_AZIMUTH_DEGREE = 0.2
+NUDGE_ELEVATION_DEGREE = 0.2
+
+# if set to true, the degrees will be flipped right before sending to the hardware
+AZIMUTH_DEGREES_FLIPPED = True
+
+
+class DishCommands():
+	def __init__(self):
+		self._dish = DishDevice()
+		self._position_initiated = False
+		self._position_azimuth_accurate = False
+		self._position_elevation_accurate = False
+		self._position_azimuth = None
+		self._position_elevation = None
+		self._nudge_left_count = 0
+		self._nudge_right_count = 0
+		self._nudge_up_count = 0
+		self._nudge_down_count = 0
+		
+		try:
+			self._dish.init_serial()
+		except:
+			error("Could not connect serial port")
+		else:
+			debug("Serial port connected\n")
+	
+	def get_position(self) -> tuple[float, float]:
+		if not self._position_initiated:
+			error("dish_commands.get_position() can't provide info without initiation")
+		
+		return float(self._position_azimuth + (self._nudge_right_count - self._nudge_left_count) * 0.2), \
+			float(self._position_elevation + (self._nudge_up_count - self._nudge_down_count) * 0.2)
+	
+	def get_int_position(self) -> tuple[int, int] | None:
+		if not self._position_initiated:
+			error("dish_commands.get_int_position() can't provide info without initiation")
+		
+		if not self.position_accurate():  # returns None, if int precision isn't enough
+			return None
+		return self._position_azimuth, self._position_elevation
+	
+	def position_accurate(self) -> bool:
+		if not self._position_initiated:
+			error("dish_commands.position_accurate() can't provide info without initiation")
+		
+		if self._position_azimuth_accurate and self._position_elevation_accurate:
+			return True
+		return False
+	
+	def get_signal_strength(self):
+		
+		signal_strength = -1
+		reply = ""
+		
+		# this seems necessary to avoid SerialException issue? (probably also kludgy)
+		while True:
+			try:
+				self._dish.reset_input_buffer()  # avoid overflow
+				
+				# request signal strength
+				self._dish.write("rfwatch 1\r")
+				
+				self._dish.flush()
+				self._dish.reset_output_buffer()
+				
+				reply = self._dish.read(207).decode().strip()  # read dish response
+			
+			except SerialException as e:
+				# dish hasn't replied yet
+				sleep(0.1)
+				continue
+			else:
+				print('')
+			break
+		
+		if reply != "":
+			header, *readings = reply.split('[5D')  # Split into list of signal strengths
+			output = readings[0]  # grab first list element
+			output = re.sub(r'\p{C}', '', output)  # remove any control chars
+			output = re.sub('[^\d]', '', output).strip()  # clean up partial garbage
+			
+			try:
+				signal_strength = int(output)  # convert to integer
+			except ValueError:
+				signal_strength = -1
+		else:
+			warning("signal strength report unexpectedly empty")
+		
+		if signal_strength == -1:
+			warning("signal strength could not be determined")
+		
+		return signal_strength
+	
+	def _set_azimuth_position(self, azimuth: int):
+		self._position_azimuth = azimuth
+		self._position_azimuth_accurate = True
+		self._nudge_left_count = 0
+		self._nudge_right_count = 0
+	
+	def _set_elevation_position(self, elevation: int):
+		self._position_elevation = elevation
+		self._position_elevation_accurate = True
+		self._nudge_up_count = 0
+		self._nudge_down_count = 0
+	
+	def goto_azimuth(self, azimuth: int):
+		if not self._position_initiated:
+			error("dish_commands.goto_azimuth() can't got to specific azimuth without initiation")
+		
+		if not self._check_input_azimuth(azimuth):
+			error(
+				"dish_commands.goto_azimuth() can't accept azimuth '%i' - out of bound (%i-%i)" % (azimuth, MINIMAL_AZIMUTH_INPUT,
+				                                                                                   MAXIMAL_AZIMUTH_INPUT)
+				)
+		
+		distance = abs(self._position_azimuth - azimuth)
+		
+		if distance > 0 or not self._position_azimuth_accurate:
+			self._send_azimuth(azimuth)
+			# wait appropriate time for the requested distance of movement
+			wait_time = MOTION_TIME_360_AZIMUTH * (distance / 360)
+			if wait_time < MINIMAL_MOTION_TIME_AZIMUTH:
+				wait_time = MINIMAL_MOTION_TIME_AZIMUTH
+			sleep(wait_time)
+			
+			self._set_azimuth_position(azimuth)
+		else:
+			warning("requested azimuth was already established")
+	
+	def goto_elevation(self, elevation: int):
+		if not self._position_initiated:
+			error("dish_commands.goto_elevation() can't got to specific elevation without initiation")
+		
+		if not self._check_input_elevation(elevation):
+			error(
+				"dish_commands.goto_elevation() can't accept elevation '%i' - out of bound (%i-%i)" % (elevation, MINIMAL_ELEVATION_INPUT,
+				                                                                                       MAXIMAL_ELEVATION_INPUT)
+				)
+		
+		distance = abs(self._position_elevation - elevation)
+		
+		if distance > 0 or not self._position_elevation_accurate:
+			self._send_elevation(elevation)
+			# wait appropriate time for the requested distance of movement
+			
+			wait_time = MOTION_TIME_180_ELEVATION * (distance / 180)
+			if wait_time < MINIMAL_MOTION_TIME_ELEVATION:
+				wait_time = MINIMAL_MOTION_TIME_ELEVATION
+			sleep(wait_time)
+			
+			self._set_elevation_position(elevation)
+		else:
+			warning("requested elevation was already established")
+	
+	def _check_input_azimuth(self, azimuth: int) -> bool:
+		if MINIMAL_AZIMUTH_INPUT <= azimuth <= MAXIMAL_AZIMUTH_INPUT:
+			return True
+		return False
+	
+	def _check_input_elevation(self, elevation: int) -> bool:
+		if MINIMAL_ELEVATION_INPUT <= elevation <= MAXIMAL_ELEVATION_INPUT:
+			return True
+		return False
+	
+	def _send_azimuth(self, azimuth: int, flush=True):
+		
+		if AZIMUTH_DEGREES_FLIPPED:
+			azimuth = abs(azimuth - 360)
+			if azimuth == 360:
+				azimuth = 0
+		
+		self._dish.write("azangle %i\r" % azimuth)
+		
+		if flush:
+			self._dish.flush()
+			self._dish.reset_output_buffer()
+	
+	def _send_elevation(self, elevation: int, flush=True):
+		self._dish.write("elangle %i\r" % elevation)
+		
+		if flush:
+			self._dish.flush()
+			self._dish.reset_output_buffer()
+			self._dish.reset_input_buffer()
+	
+	def goto_xy(self, azimuth: int, elevation: int) -> None:
+		
+		if not self._position_initiated:
+			error("dish_commands.goto_xy() can't got to specific xy without initiation")
+		
+		if not self._check_input_azimuth(azimuth):
+			error(
+				"dish_commands.goto_xy() can't accept azimuth '%i' - out of bound (%i-%i)" % (azimuth, MINIMAL_AZIMUTH_INPUT,
+				                                                                              MAXIMAL_AZIMUTH_INPUT)
+				)
+		
+		if not self._check_input_elevation(elevation):
+			error(
+				"dish_commands.goto_xy() can't accept elevation '%i' - out of bound (%i-%i)" % (elevation, MINIMAL_ELEVATION_INPUT,
+				                                                                                MAXIMAL_ELEVATION_INPUT)
+				)
+		
+		self.goto_azimuth(azimuth)
+		
+		self.goto_elevation(elevation)
+	
+	def init_dish_position(self, azimuth: int, elevation: int) -> None:
+		
+		if not self._check_input_azimuth(azimuth):
+			error(
+				"dish_commands.init_dish_position() can't accept azimuth '%i' - out of bound (%i-%i)" % (azimuth, MINIMAL_AZIMUTH_INPUT,
+				                                                                                         MAXIMAL_AZIMUTH_INPUT)
+				)
+		
+		if not self._check_input_elevation(elevation):
+			error(
+				"dish_commands.init_dish_position() can't accept elevation '%i' - out of bound (%i-%i)" % (elevation,
+				                                                                                           MINIMAL_ELEVATION_INPUT,
+				                                                                                           MAXIMAL_ELEVATION_INPUT)
+				)
+		info("Moving dish to staring position. Please wait...")
+		
+		self._send_azimuth(azimuth)
+		sleep(5)  # Give motors time to drive dish to scan origin
+		
+		self._set_azimuth_position(azimuth)
+		
+		self._send_elevation(elevation)
+		sleep(5)
+		
+		self._set_elevation_position(elevation)
+		
+		self._position_initiated = True
+	
+	def nudge_right(self, auto_align=True):
+		
+		if not self._position_initiated:
+			error("dish_commands.nudge_right() can't nudge without initiation")
+		
+		if self._nudge_left_count > 0:
+			# to avoid positioning errors by nudging up and down
+			error("dish_commands.nudge_right() cannot proceed, as azimuth has already nudged left since last absolute positioning")
+		
+		if self._nudge_right_count >= 4 and auto_align:
+			debug("next nudge would be a full degree again, doing an absolute positioning instead")
+			
+			if self._position_azimuth >= MAXIMAL_AZIMUTH_INPUT:
+				# azimut would overflow. Go to e.g. 0 instead
+				
+				self.goto_azimuth(MINIMAL_AZIMUTH_INPUT)
+			else:
+				self.goto_azimuth(self._position_azimuth + 1)
+		
+		else:
+			self._position_azimuth_accurate = False
+			self._dish.write("aznudge cw\r")
+			# wait for motor to complete command
+			sleep(NUDGE_MOTION_TIME_AZIMUTH)
+			self._nudge_right_count += 1
+	
+	def nudge_left(self, auto_align=True):
+		if not self._position_initiated:
+			error("dish_commands.nudge_left() can't nudge without initiation")
+		
+		if self._nudge_right_count > 0:
+			# to avoid positioning errors by nudging up and down
+			error("dish_commands.nudge_left() cannot proceed, as azimuth has already nudged right since last absolute positioning")
+		
+		if self._nudge_left_count >= 4 and auto_align:
+			debug("next nudge would be a full degree again, doing an absolute positioning instead")
+			
+			if self._position_azimuth <= MINIMAL_AZIMUTH_INPUT:
+				# azimut would overflow. Go to e.g. 359 instead
+				
+				self.goto_azimuth(MAXIMAL_AZIMUTH_INPUT)
+			else:
+				self.goto_azimuth(self._position_azimuth - 1)
+		
+		else:
+			self._position_azimuth_accurate = False
+			self._dish.write("aznudge ccw\r")
+			# wait for motor to complete command
+			sleep(NUDGE_MOTION_TIME_AZIMUTH)
+			self._nudge_left_count += 1
+	
+	def nudge_up(self, auto_align=True):
+		if not self._position_initiated:
+			error("dish_commands.nudge_up() can't nudge without initiation")
+		
+		if self._nudge_down_count > 0:
+			# to avoid positioning errors by nudging up and down
+			error("dish_commands.nudge_up() cannot proceed, as elevation has already nudged down since last absolute positioning")
+		
+		if self._position_elevation >= MAXIMAL_ELEVATION_INPUT:
+			error("dish_commands.nudge_up() cannot increase elevation, as it has reached its maximum")
+		
+		if self._nudge_up_count >= 4 and auto_align:
+			debug("next nudge would be a full degree again, doing an absolute positioning instead")
+			
+			self.goto_elevation(self._position_elevation + 1)
+		else:
+			self._position_elevation_accurate = False
+			self._dish.write("elnudge up\r")
+			# wait for motor to complete command
+			sleep(NUDGE_MOTION_TIME_ELEVATION)
+			self._nudge_up_count += 1
+	
+	def nudge_down(self, auto_align=True):
+		if not self._position_initiated:
+			error("dish_commands.nudge_down() can't nudge without initiation")
+		
+		if self._nudge_up_count > 0:
+			# to avoid positioning errors by nudging up and down
+			error("dish_commands.nudge_down() cannot proceed, as elevation has already nudged up since last absolute positioning")
+		
+		if self._position_elevation <= MINIMAL_ELEVATION_INPUT:
+			error("dish_commands.nudge_down() cannot decrease elevation, as it has reached its minimum")
+		
+		if self._nudge_down_count >= 4 and auto_align:
+			debug("next nudge would be a full degree again, doing an absolute positioning instead")
+			
+			self.goto_elevation(self._position_elevation - 1)
+		
+		else:
+			self._position_elevation_accurate = False
+			self._dish.write("elnudge down\r")
+			# wait for motor to complete command
+			sleep(NUDGE_MOTION_TIME_ELEVATION)
+			self._nudge_down_count += 1
+	
+	def close_conn(self):
+		self._dish.close()

--- a/lib/dish_serial.py
+++ b/lib/dish_serial.py
@@ -1,0 +1,66 @@
+from serial import EIGHTBITS, PARITY_NONE, Serial, STOPBITS_ONE
+
+from console_messages import error
+
+
+class DishDevice:
+	def __init__(self, device='/dev/ttyACM0', baud_rate=9600, parity=PARITY_NONE, stopbits=STOPBITS_ONE, bytesize=EIGHTBITS,
+			serial_timeout=1):
+		self.timeout = serial_timeout
+		self.bytesize = bytesize
+		self.stopbits = stopbits
+		self.parity = parity
+		self.device = device
+		self.baud_rate = baud_rate
+		
+		self.dish_serial = None
+	
+	def init_serial(self):
+		self.dish_serial = Serial(
+			port=self.device, baudrate=self.baud_rate, bytesize=self.bytesize, parity=self.parity,
+			stopbits=self.stopbits, timeout=self.timeout
+			)
+	
+	def write(self, message: str):
+		byte_message = bytes(message, 'utf-8')
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not write message in serial_dish.write(): Serial not (yet) connected")
+		
+		for b in byte_message:
+			self.dish_serial.write(b)
+	
+	def flush(self) -> None:
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not flush in serial_dish.flush(): Serial not (yet) connected")
+		
+		self.dish_serial.flush()
+	
+	def reset_output_buffer(self) -> None:
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not reset_output_buffer in serial_dish.reset_output_buffer(): Serial not (yet) connected")
+		
+		self.dish_serial.reset_output_buffer()
+	
+	def reset_input_buffer(self) -> None:
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not reset_input_buffer in serial_dish.reset_input_buffer(): Serial not (yet) connected")
+		
+		self.dish_serial.reset_input_buffer()
+	
+	def read(self, size: int = 1) -> bytes | None:
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not read in serial_dish.read(): Serial not (yet) connected")
+		
+		return self.dish_serial.read(size)
+	
+	def close(self) -> None:
+		
+		if self.dish_serial is None or not isinstance(self.dish_serial, Serial):
+			error("Could not close in serial_dish.close(): Serial not (yet) connected")
+		
+		self.dish_serial.close()

--- a/lib/questions.py
+++ b/lib/questions.py
@@ -1,0 +1,19 @@
+from console_messages import warning
+
+
+def get_valid_int(description: str, default: int, minimum: int, maximum: int) -> int:
+	value = input("Enter %s (%i-%i; default %i): " % (description, minimum, maximum, default))
+	try:
+		value = int(value)
+	except ValueError:
+		value = default
+	
+	if type(value) != int:
+		return default
+	elif value > maximum:
+		warning("Entered '%s' was too large, using maximal allowed value (%i)." % (description, maximum))
+		return maximum
+	elif value < minimum:
+		warning("Entered '%s' was too small, using minimal allowed value (%i)." % (description, minimum))
+		return maximum
+	return value

--- a/lib/time_formatting.py
+++ b/lib/time_formatting.py
@@ -1,0 +1,5 @@
+from datetime import datetime as dt
+
+
+def timestamp():
+	return dt.now().replace(microsecond=0).isoformat(' ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 #Package requirements for dish_scan.py and dish_image.py
 
-numpy
-pyserial
-regex
-matplotlib
+numpy~=1.24.2
+pyserial~=3.5
+regex~=2023.3.23
+matplotlib~=3.7.1
 
 
+
+Pillow~=9.5.0


### PR DESCRIPTION
- move dish commands in two seperate classes, one for low level serial access and one for high level commands
- cleanup duplicate codes
- do input validations
- work with normal azimuth degrees; flip only when sending to device
- automatically aligns nudges with a regular goto command, to reset the drift after 5 nudges again
- keeps track of the absolute position (including nudges) of the dish, for future use (in algorithms)